### PR TITLE
Develop 0.0.6 bak

### DIFF
--- a/docs/script/startup.sh
+++ b/docs/script/startup.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 # -f / --force: 若服务已运行则直接停止，不提示确认
+# -d / --debug: 启用 Java 远程调试（端口为 app_port + 1000）
 FORCE_STOP=0
+ENABLE_DEBUG=0
 for arg in "$@"; do
     case "$arg" in
         -f|--force) FORCE_STOP=1 ;;
+        -d|--debug) ENABLE_DEBUG=1 ;;
     esac
 done
 
@@ -14,6 +17,8 @@ app_version="0.0.1-SNAPSHOT"
 app_port="30008"
 app_active=test
 java_opts="-Xms1536m -Xmx1536m -Xmn512m -Xss256K"
+# 调试参数：仅 -d/--debug 时生效
+[ "$ENABLE_DEBUG" -eq 1 ] && java_debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$((app_port + 1000))" || java_debug=""
 
 # ============ 日志管理配置 ============
 LOG_FILE="console.log"
@@ -151,7 +156,7 @@ check_and_handle_running
 clean_by_size
 
 # 启动应用
-nohup java -server -Duser.timezone=Asia/Shanghai -jar $java_opts ${app_name}-${app_version}.jar \
+nohup java -server -Duser.timezone=Asia/Shanghai -jar $java_opts $java_debug ${app_name}-${app_version}.jar \
     --spring.profiles.active=$app_active --server.port=$app_port --spring.application.name=$app_name \
     >> "$LOG_FILE" 2>&1 &
 
@@ -164,4 +169,5 @@ ROTATE_PID=$!
 echo "${app_name}-${app_version} 服务启动成功"
 echo "  日志文件: $LOG_FILE"
 echo "  日志备份: $BACKUP_DIR (超过 $MAX_SIZE 时自动备份，保留最近 $MAX_BACKUPS 个)"
+[ "$ENABLE_DEBUG" -eq 1 ] && echo "  调试端口: $((app_port + 1000)) (已启用 -d)"
 echo "  进程 PID: $JAVA_PID"

--- a/docs/script/startup.sh
+++ b/docs/script/startup.sh
@@ -1,12 +1,167 @@
 #!/bin/bash
 
+# -f / --force: 若服务已运行则直接停止，不提示确认
+FORCE_STOP=0
+for arg in "$@"; do
+    case "$arg" in
+        -f|--force) FORCE_STOP=1 ;;
+    esac
+done
+
+# ============ 应用配置 ============
 app_name="yz-unqid-startup"
 app_version="0.0.1-SNAPSHOT"
 app_port="30008"
 app_active=test
-
 java_opts="-Xms1536m -Xmx1536m -Xmn512m -Xss256K"
 
-nohup java -server -Duser.timezone=Asia/Shanghai -jar $java_opts ${app_name}-${app_version}.jar --spring.profiles.active=$app_active --server.port=$app_port --spring.application.name=$app_name >> console.log 2>&1 &
+# ============ 日志管理配置 ============
+LOG_FILE="console.log"
+BACKUP_DIR="./log_backups"
+MAX_SIZE="100M"
+MAX_BACKUPS=30
+CHECK_INTERVAL=300   # 检查间隔（秒），默认 5 分钟
 
-echo "${app_name}-${app_version}服务启动成功"
+# 将大小字符串转为字节数
+convert_to_bytes() {
+    local size=$1
+    local bytes
+    case "$size" in
+        *G) bytes=$(( ${size%G} * 1024 * 1024 * 1024 )) ;;
+        *M) bytes=$(( ${size%M} * 1024 * 1024 )) ;;
+        *K) bytes=$(( ${size%K} * 1024 )) ;;
+        *)  bytes=$size ;;
+    esac
+    echo $bytes
+}
+
+# 备份并清空日志
+backup_and_clean() {
+    mkdir -p "$BACKUP_DIR"
+    if [ -f "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
+        backup_file="$BACKUP_DIR/console_$(date +%Y%m%d_%H%M%S).log"
+        cp "$LOG_FILE" "$backup_file"
+        > "$LOG_FILE"
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] 已备份到 $backup_file 并清空原文件"
+
+        # 清理旧备份，只保留最近 MAX_BACKUPS 个
+        ls -t "$BACKUP_DIR"/console_*.log 2>/dev/null | tail -n +$(($MAX_BACKUPS + 1)) | xargs rm -f 2>/dev/null
+    fi
+}
+
+# 按大小检查并轮转：超过 MAX_SIZE 时备份并清空
+clean_by_size() {
+    if [ ! -f "$LOG_FILE" ]; then
+        return
+    fi
+
+    FILE_SIZE=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
+    MAX_SIZE_BYTES=$(convert_to_bytes "$MAX_SIZE")
+
+    if [ "$FILE_SIZE" -gt "$MAX_SIZE_BYTES" ]; then
+        backup_and_clean
+    fi
+}
+
+# 后台日志轮转循环：定期检查，当主进程退出时停止
+log_rotate_loop() {
+    local main_pid=$1
+    while kill -0 $main_pid 2>/dev/null; do
+        sleep $CHECK_INTERVAL
+        clean_by_size
+    done
+}
+
+# 获取占用 app_port 的进程 PID 列表
+get_running_pids() {
+    # lsof 兼容 macOS 与 Linux
+    lsof -t -i ":$app_port" 2>/dev/null
+}
+
+# 停止正在运行的服务
+stop_running_service() {
+    local pids
+    pids=$(get_running_pids)
+    if [ -z "$pids" ]; then
+        return 0
+    fi
+
+    echo "正在停止服务 (PID: $pids)..."
+    for pid in $pids; do
+        kill -TERM "$pid" 2>/dev/null
+    done
+
+    # 等待进程退出，最多 30 秒
+    local wait_count=0
+    while [ $wait_count -lt 30 ]; do
+        pids=$(get_running_pids)
+        if [ -z "$pids" ]; then
+            echo "服务已停止"
+            return 0
+        fi
+        sleep 1
+        wait_count=$((wait_count + 1))
+    done
+
+    # 超时则强制 kill
+    echo "未能在 30 秒内退出，强制终止..."
+    pids=$(get_running_pids)
+    for pid in $pids; do
+        kill -9 "$pid" 2>/dev/null
+    done
+    sleep 1
+    echo "服务已强制停止"
+}
+
+# 检查服务是否运行，若运行则提示并处理
+check_and_handle_running() {
+    local pids
+    pids=$(get_running_pids)
+    if [ -z "$pids" ]; then
+        return 0
+    fi
+
+    echo "服务正在运行 (端口: $app_port, PID: $pids)"
+
+    if [ "$FORCE_STOP" -eq 1 ]; then
+        echo "使用 -f 参数，直接停止已运行的服务"
+        stop_running_service
+        return 0
+    fi
+
+    echo -n "是否停止正在运行的服务？(y/n): "
+    read -r answer
+
+    case "$answer" in
+        [yY]|[yY][eE][sS])
+            stop_running_service
+            return 0
+            ;;
+        *)
+            echo "已取消启动"
+            exit 1
+            ;;
+    esac
+}
+
+# 运行前检查：若服务已在运行则提示并处理
+check_and_handle_running
+
+# 启动前检查并轮转现有日志（若上次运行的日志已超限）
+clean_by_size
+
+# 启动应用
+nohup java -server -Duser.timezone=Asia/Shanghai -jar $java_opts ${app_name}-${app_version}.jar \
+    --spring.profiles.active=$app_active --server.port=$app_port --spring.application.name=$app_name \
+    >> "$LOG_FILE" 2>&1 &
+
+JAVA_PID=$!
+
+# 启动后台日志轮转进程（随 Java 进程退出而退出）
+log_rotate_loop $JAVA_PID &
+ROTATE_PID=$!
+
+echo "${app_name}-${app_version} 服务启动成功"
+echo "  日志文件: $LOG_FILE"
+echo "  日志备份: $BACKUP_DIR (超过 $MAX_SIZE 时自动备份，保留最近 $MAX_BACKUPS 个)"
+echo "  进程 PID: $JAVA_PID"

--- a/mall-admin/mall-sys-startup/pom.xml
+++ b/mall-admin/mall-sys-startup/pom.xml
@@ -26,6 +26,12 @@
 
         <dependency>
             <groupId>com.yz</groupId>
+            <artifactId>mall-backup-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yz</groupId>
             <artifactId>mall-serial-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/mall-admin/mall-sys-startup/src/main/resources/application.yaml
+++ b/mall-admin/mall-sys-startup/src/main/resources/application.yaml
@@ -13,29 +13,6 @@ spring:
 #      - nacos:rabbitmq.yaml?group=DEFAULT_GROUP&refreshEnabled=true
 #      - nacos:file.yaml?group=DEFAULT_GROUP&refreshEnabled=true
 
-  datasource:
-    druid:
-      web-stat-filter:
-        enabled: false
-        url-pattern: /*
-        exclusions: "*.js,*.gif,*.jpg,*.png,*.css,*.ico,/druid/*"
-        session-stat-enable: true
-        session-stat-max-count: 1000
-      stat-view-servlet:
-        enabled: true
-        url-pattern: /druid/*
-        reset-enable: false
-        login-password: s8F3as09
-        login-username: root
-        allow: 127.0.0.1
-      filter:
-        # 开启 druiddatasource 的状态监控
-        stat:
-          enabled: false
-          db-type: mysql
-      # Spring 监控，利用aop 对指定接口的执行时间，jdbc数进行记录
-      aop-patterns: "com.yz.mall.*"
-
   cloud:
     openfeign:
       circuitbreaker:
@@ -51,7 +28,7 @@ management:
 xxl:
   job:
     admin:
-      addresses: http://192.168.3.237:30009/xxl-job-admin
+      addresses: http://${XXL_JOB_ADMIN_HOST}:30009/xxl-job-admin
 #      addresses: http://192.168.3.29:30009/xxl-job-admin
       accessToken: 123456789
       timeout: 3
@@ -73,7 +50,7 @@ yz:
         expire-after-access: 0
         
 rocketmq:
-  name-server: 192.168.3.237:9876
+  name-server: ${ROCKET_MQ_HOST}:9876
   producer:
     group: producer-mall-sys
   consumer:

--- a/mall-admin/mall-sys-startup/src/main/resources/bootstrap.yaml
+++ b/mall-admin/mall-sys-startup/src/main/resources/bootstrap.yaml
@@ -3,7 +3,7 @@ spring:
     compatibility-verifier:
       enabled: false
     nacos:
-      server-addr: yunze.com:8848
+      server-addr: ${NACOS_HOST}:8848
       username: nacos
       password: ${NACOS_PASSWORD}
       config:

--- a/mall-admin/pom.xml
+++ b/mall-admin/pom.xml
@@ -18,6 +18,7 @@
         <module>mall-sys-interface</module>
         <module>mall-sys-core</module>
         <module>mall-sys-feign</module>
+        <module>mall-backup-core</module>
         <module>mall-sys-startup</module>
     </modules>
 

--- a/mall-gateway/src/main/resources/bootstrap.yaml
+++ b/mall-gateway/src/main/resources/bootstrap.yaml
@@ -7,7 +7,7 @@ spring:
     compatibility-verifier:
       enabled: false
     nacos:
-      server-addr: yunze.com:8848
+      server-addr: ${NACOS_HOST}:8848
       username: nacos
       password: ${NACOS_PASSWORD}
       config:

--- a/mall-oms/mall-oms-startup/src/main/resources/bootstrap.yaml
+++ b/mall-oms/mall-oms-startup/src/main/resources/bootstrap.yaml
@@ -3,7 +3,7 @@ spring:
     compatibility-verifier:
       enabled: false
     nacos:
-      server-addr: yunze.com:8848
+      server-addr: ${NACOS_HOST}:8848
       username: nacos
       password: ${NACOS_PASSWORD}
       config:
@@ -19,7 +19,7 @@ spring:
         namespace: ff6944dd-b11f-4403-8245-6c621b2f54c8
 
 rocketmq:
-  name-server: 192.168.3.237:9876
+  name-server: ${ROCKET_MQ_HOST}:9876
   producer:
     group: producer-mall-oms
   consumer:

--- a/mall-oms/mall-oms-startup/src/main/resources/logback-spring.xml
+++ b/mall-oms/mall-oms-startup/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="false">
     <!--设置存储路径变量-->
-    <property name="LOG_HOME" value="./logs/oms/"/>
+    <property name="LOG_HOME" value="./logs/oms"/>
 
     <!--控制台输出appender-->
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
@@ -54,6 +54,6 @@
         <!--appender将会添加到这个loger-->
         <appender-ref ref="console"/>
         <appender-ref ref="timeFileOutput"/>
-<!--        <appender-ref ref="logstash"/>-->
+        <appender-ref ref="logstash"/>
     </root>
 </configuration>

--- a/mall-pms/mall-pms-core/src/main/java/com/yz/mall/pms/service/PmsAttrService.java
+++ b/mall-pms/mall-pms-core/src/main/java/com/yz/mall/pms/service/PmsAttrService.java
@@ -41,7 +41,7 @@ public interface PmsAttrService extends IService<PmsAttr> {
      * @param filter 过滤条件
      * @return 分页列表数据
      */
-    Page<PmsAttr> page(PageFilter<PmsAttrQueryDto> filter);
+    Page<PmsAttrVo> page(PageFilter<PmsAttrQueryDto> filter);
 
     /**
      * 详情查询

--- a/mall-pms/mall-pms-core/src/main/java/com/yz/mall/pms/service/impl/PmsAttrServiceImpl.java
+++ b/mall-pms/mall-pms-core/src/main/java/com/yz/mall/pms/service/impl/PmsAttrServiceImpl.java
@@ -8,8 +8,10 @@ import com.yz.mall.pms.dto.PmsAttrAddDto;
 import com.yz.mall.pms.dto.PmsAttrQueryDto;
 import com.yz.mall.pms.dto.PmsAttrUpdateDto;
 import com.yz.mall.pms.entity.PmsAttr;
+import com.yz.mall.pms.entity.PmsProduct;
 import com.yz.mall.pms.mapper.PmsAttrMapper;
 import com.yz.mall.pms.service.PmsAttrService;
+import com.yz.mall.pms.service.PmsProductService;
 import com.yz.mall.pms.vo.PmsAttrVo;
 import com.yz.mall.base.PageFilter;
 import org.springframework.beans.BeanUtils;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -28,6 +31,12 @@ import java.util.stream.Collectors;
  */
 @Service
 public class PmsAttrServiceImpl extends ServiceImpl<PmsAttrMapper, PmsAttr> implements PmsAttrService {
+
+    private final PmsProductService pmsProductService;
+
+    public PmsAttrServiceImpl(PmsProductService pmsProductService) {
+        this.pmsProductService = pmsProductService;
+    }
 
     @Transactional
     @Override
@@ -47,7 +56,7 @@ public class PmsAttrServiceImpl extends ServiceImpl<PmsAttrMapper, PmsAttr> impl
     }
 
     @Override
-    public Page<PmsAttr> page(PageFilter<PmsAttrQueryDto> filter) {
+    public Page<PmsAttrVo> page(PageFilter<PmsAttrQueryDto> filter) {
         PmsAttrQueryDto query = filter.getFilter();
         LambdaQueryWrapper<PmsAttr> queryWrapper = new LambdaQueryWrapper<>();
 
@@ -57,7 +66,22 @@ public class PmsAttrServiceImpl extends ServiceImpl<PmsAttrMapper, PmsAttr> impl
         queryWrapper.like(StringUtils.hasText(query.getAttrValue()), PmsAttr::getAttrValue, query.getAttrValue());
 
         queryWrapper.orderByDesc(PmsAttr::getId);
-        return baseMapper.selectPage(new Page<>(filter.getCurrent(), filter.getSize()), queryWrapper);
+        Page<PmsAttr> page = baseMapper.selectPage(new Page<>(filter.getCurrent(), filter.getSize()), queryWrapper);
+        // 从商品表中查询商品名称
+        List<Long> productIds = page.getRecords().stream().map(PmsAttr::getRelatedId).distinct().collect(Collectors.toList());
+        List<PmsProduct> products = pmsProductService.listByIds(productIds);
+        Map<Long, String> productNameMap = products.stream().collect(Collectors.toMap(PmsProduct::getId, PmsProduct::getProductName));
+        // 转换Page<PmsAttr>为Page<PmsAttrVo>
+        Page<PmsAttrVo> voPage = new Page<>();
+        voPage.setTotal(page.getTotal());
+        List<PmsAttrVo> voList = page.getRecords().stream().map(item -> {
+            PmsAttrVo vo = new PmsAttrVo();
+            BeanUtils.copyProperties(item, vo);
+            vo.setProductName(productNameMap.get(item.getRelatedId()));
+            return vo;
+        }).collect(Collectors.toList());
+        voPage.setRecords(voList);
+        return voPage;
     }
 
     @Override

--- a/mall-pms/mall-pms-dao/src/main/java/com/yz/mall/pms/vo/PmsAttrVo.java
+++ b/mall-pms/mall-pms-dao/src/main/java/com/yz/mall/pms/vo/PmsAttrVo.java
@@ -68,4 +68,8 @@ public class PmsAttrVo implements Serializable {
     @DateTimeFormat(pattern = DatePattern.NORM_DATETIME_PATTERN)
     private LocalDateTime updateTime;
 
+    /**
+     * 商品名称
+     */
+    private String productName;
 }

--- a/mall-pms/mall-pms-dao/src/main/resources/mapper/PmsProductMapper.xml
+++ b/mall-pms/mall-pms-dao/src/main/resources/mapper/PmsProductMapper.xml
@@ -7,9 +7,7 @@
         from pms_product pp
         where pp.invalid = 0 and pp.publish_status = 1 and pp.verify_status = 1
         <if test="filter.lastProductId != null and filter.lastProductId != ''">and pp.id &lt; #{filter.lastProductId}</if>
-        <if test="filter.queryInfo != null and filter.queryInfo != ''">
-          and (pp.name like concat('%', #{filter.queryInfo}, '%') or pp.titles like concat('%', #{filter.queryInfo}, '%'))
-        </if>
+        <if test="filter.queryInfo != null and filter.queryInfo != ''">and pp.product_name like concat('%', #{filter.queryInfo}, '%')</if>
         order by pp.id desc
         limit 20
     </select>

--- a/mall-pms/mall-pms-startup/src/main/java/com/yz/mall/pms/controller/PmsAttrController.java
+++ b/mall-pms/mall-pms-startup/src/main/java/com/yz/mall/pms/controller/PmsAttrController.java
@@ -67,8 +67,8 @@ public class PmsAttrController extends ApiController {
      */
     @SaCheckPermission("api:pms:attr:page")
     @PostMapping("page")
-    public Result<ResultTable<PmsAttr>> page(@RequestBody @Valid PageFilter<PmsAttrQueryDto> filter) {
-        Page<PmsAttr> page = this.service.page(filter);
+    public Result<ResultTable<PmsAttrVo>> page(@RequestBody @Valid PageFilter<PmsAttrQueryDto> filter) {
+        Page<PmsAttrVo> page = this.service.page(filter);
         return success(page.getRecords(), page.getTotal());
     }
 

--- a/mall-pms/mall-pms-startup/src/main/resources/bootstrap.yaml
+++ b/mall-pms/mall-pms-startup/src/main/resources/bootstrap.yaml
@@ -3,7 +3,7 @@ spring:
     compatibility-verifier:
       enabled: false
     nacos:
-      server-addr: yunze.com:8848
+      server-addr: ${NACOS_HOST}:8848
       username: nacos
       password: ${NACOS_PASSWORD}
       config:
@@ -13,7 +13,6 @@ spring:
         extension-configs:
           - data-id: datasource.yaml
           - data-id: sa-token.yaml
-#          - data-id: rabbitmq.yaml
           - data-id: xxl-job-admin.yaml
       discovery:
         namespace: ff6944dd-b11f-4403-8245-6c621b2f54c8
@@ -25,13 +24,13 @@ xxl:
     executor:
       appname: xxl-job-executor-sample # 执行器AppName [选填]：执行器心跳注册分组依据；为空则关闭自动注册
       address: http://${LOCAL_HOST}:20005/  # 执行器注册 [选填]：优先使用该配置作为注册地址，为空时使用内嵌服务 ”IP:PORT“ 作为注册地址。从而更灵活的支持容器类型执行器动态IP和动态映射端口问题。
-      ip: 127.0.0.1                 # 执行器IP [选填]：默认为空表示自动获取IP，多网卡时可手动设置指定IP，该IP不会绑定Host仅作为通讯实用；地址信息用于 "执行器注册" 和 "调度中心请求并触发任务"；
+      ip: ${LOCAL_HOST}             # 执行器IP [选填]：默认为空表示自动获取IP，多网卡时可手动设置指定IP，该IP不会绑定Host仅作为通讯实用；地址信息用于 "执行器注册" 和 "调度中心请求并触发任务"；
       port: 20005                   # 执行器端口号 [选填]：小于等于0则自动获取；默认端口为9999，单机部署多个执行器时，注意要配置不同执行器端口；
       logpath: ./logs/jobhandler    # 执行器运行日志文件存储磁盘路径 [选填] ：需要对该路径拥有读写权限；为空则使用默认路径；
       logretentiondays: 7           # 执行器日志文件保存天数 [选填] ： 过期日志自动清理, 限制值大于等于3时生效; 否则, 如-1, 关闭自动清理功能；
 
 rocketmq:
-  name-server: 192.168.3.237:9876
+  name-server: ${ROCKET_MQ_HOST}:9876
   producer:
     group: producer-mall-pms
   consumer:

--- a/mall-pms/mall-pms-startup/src/main/resources/logback-spring.xml
+++ b/mall-pms/mall-pms-startup/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="false">
     <!--设置存储路径变量-->
-    <property name="LOG_HOME" value="./logs/pms/"/>
+    <property name="LOG_HOME" value="./logs/pms"/>
 
     <!--控制台输出appender-->
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
@@ -33,7 +33,7 @@
         <!--输出格式-->
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <!--格式化输出：%d表示日期，%thread表示线程名，%-5level：级别从左显示5个字符宽度%msg：日志消息，%n是换行符-->
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{70} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{trace_id}] %logger{70} - %msg%n</pattern>
             <!--设置编码-->
             <charset>UTF-8</charset>
         </encoder>

--- a/mall-utils/mall-web/src/main/java/com/yz/mall/web/interceptor/RequestHeaderInterceptor.java
+++ b/mall-utils/mall-web/src/main/java/com/yz/mall/web/interceptor/RequestHeaderInterceptor.java
@@ -36,10 +36,4 @@ public class RequestHeaderInterceptor implements HandlerInterceptor {
         return true;
     }
 
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-        // 清理 MDC，防止内存泄漏和线程复用污染
-        MDC.clear();
-    }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <sa-token.version>1.43.0</sa-token.version>
         <xxl-job.version>3.1.1</xxl-job.version>
         <jackson.version>2.19.2</jackson.version>
-        <qof.version>17.0.4-SNAPSHOT</qof.version>
+        <qof.version>17.0.4</qof.version>
         <logback.version>1.5.18</logback.version>
         <resilience4j.version>2.2.0</resilience4j.version>
         <logstash-logback.version>6.6</logstash-logback.version>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches request logging/MDC lifecycle and service startup/configuration, which can affect observability and deployments; the PMS paging change alters API response types and adds cross-entity lookups that could impact performance and clients.
> 
> **Overview**
> Enhances `docs/script/startup.sh` with **safe restarts** (detect/stop existing process on the app port, optional `-f`) and **optional remote debugging** (`-d`, port = `app_port + 1000`), plus a simple size-based `console.log` rotation/backup loop.
> 
> Shifts multiple services’ configs to **environment-variable-driven endpoints** (Nacos/XXL-Job/RocketMQ) and tweaks logging: enable Logstash output in OMS, normalize `LOG_HOME` paths, add `trace_id` to PMS file log pattern, and update root `qof` version from snapshot to release.
> 
> Updates PMS attribute paging to return `PmsAttrVo` (including new `productName`) by joining via `PmsProductService`, and adjusts the controller API types accordingly; also tightens product display search SQL to query only `product_name` (dropping `titles`). Adds `mall-backup-core` as an admin module/dependency. Removes MDC cleanup in `RequestHeaderInterceptor` (no `afterCompletion`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f97191fb2fdd2266a1c2c58cff54e14679ca572d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->